### PR TITLE
Use a single stage to allow building images once and pushing them

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,42 +12,16 @@ env:
 
 jobs:
     include:
-        - stage: Build
-          name: Docker images
-          script:
-              - travis_retry docker-compose --file docker-compose.yaml build
-              - travis_retry docker-compose --file docker-compose.yaml --file docker-compose.test.yaml build
-
-        - stage: Test
-          name: Smoke tests
-          #install:
-          #    - travis_retry docker-compose --file docker-compose.yaml pull
-          before_script:
-              - docker-compose --file docker-compose.yaml up -d web
-          script:
-              - docker-compose exec app bin/console --version
-              - if [[ $(curl -sS http://localhost:8080/ping 2>&1) == "pong" ]]; then true; else false; fi
-
         - stage: Test
           name: Tests
           script:
+              - travis_retry docker-compose --file docker-compose.yaml build
+              - travis_retry docker-compose --file docker-compose.yaml --file docker-compose.test.yaml build
+              - docker-compose --file docker-compose.yaml up -d web && - docker-compose exec app bin/console --version
+              - if [[ $(curl -sS http://localhost:8080/ping 2>&1) == "pong" ]]; then true; else false; fi
               - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run app vendor/bin/phpunit
-
-        - stage: Code Quality
-          name: Coding standards
-          script:
               - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run app vendor/bin/phpcs -p
-
-        - stage: Code Quality
-          name: Static analysis
-          script:
               - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run -e APP_ENV=dev app sh -c "bin/console cache:warmup --no-optional-warmers && vendor/bin/phpstan analyse"
-
-stages:
-    - Build
-    - Test
-    - name: Code Quality
-      if: type = pull_request
 
 if: |
     branch = master OR \

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ jobs:
               - travis_retry docker-compose --file docker-compose.yaml --file docker-compose.test.yaml build
           script:
               - .travis/test/smoke
-              - echo "Failing check" && bash -c "exit 42;"
               - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run app vendor/bin/phpunit
               - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run app vendor/bin/phpcs -p
               - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run -e APP_ENV=dev app sh -c "bin/console cache:warmup --no-optional-warmers && vendor/bin/phpstan analyse"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
               - travis_retry docker-compose --file docker-compose.yaml --file docker-compose.test.yaml build
               - docker-compose --file docker-compose.yaml up -d web
               - docker-compose --file docker-compose.yaml exec app bin/console --version
-              - if [[ $(curl -sS http://localhost:8080/ping 2>&1) == "pong" ]]; then true; else false; fi
+              - [[ $(curl -sS http://localhost:8080/ping 2>&1) == "pong" ]]
               - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run app vendor/bin/phpunit
               - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run app vendor/bin/phpcs -p
               - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run -e APP_ENV=dev app sh -c "bin/console cache:warmup --no-optional-warmers && vendor/bin/phpstan analyse"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,7 @@ jobs:
           script:
               - travis_retry docker-compose --file docker-compose.yaml build
               - travis_retry docker-compose --file docker-compose.yaml --file docker-compose.test.yaml build
-              - docker-compose --file docker-compose.yaml up -d web
-              - docker-compose --file docker-compose.yaml exec app bin/console --version
-              - [[ $(curl -sS http://localhost:8080/ping 2>&1) == "pong" ]]
+              - .travis/test/smoke
               - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run app vendor/bin/phpunit
               - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run app vendor/bin/phpcs -p
               - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run -e APP_ENV=dev app sh -c "bin/console cache:warmup --no-optional-warmers && vendor/bin/phpstan analyse"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,19 @@ env:
         - APP_SECRET=secret
         - IMAGE_TAG=$TRAVIS_COMMIT
 
-install:
-    - travis_retry docker-compose --file docker-compose.yaml --file docker-compose.test.yaml build
 
 jobs:
     include:
+        - stage: Build
+          name: Docker images
+          script:
+              - travis_retry docker-compose --file docker-compose.yaml build
+              - travis_retry docker-compose --file docker-compose.yaml --file docker-compose.test.yaml build
 
         - stage: Test
           name: Smoke tests
-          install:
-              - travis_retry docker-compose --file docker-compose.yaml build
+          #install:
+          #    - travis_retry docker-compose --file docker-compose.yaml pull
           before_script:
               - docker-compose --file docker-compose.yaml up -d web
           script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,19 +9,15 @@ env:
         - APP_SECRET=secret
         - IMAGE_TAG=$TRAVIS_COMMIT
 
+install:
+    - travis_retry docker-compose --file docker-compose.yaml build
+    - travis_retry docker-compose --file docker-compose.yaml --file docker-compose.test.yaml build
 
-jobs:
-    include:
-        - stage: Test
-          name: Tests
-          install:
-              - travis_retry docker-compose --file docker-compose.yaml build
-              - travis_retry docker-compose --file docker-compose.yaml --file docker-compose.test.yaml build
-          script:
-              - .travis/test/smoke
-              - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run app vendor/bin/phpunit
-              - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run app vendor/bin/phpcs -p
-              - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run -e APP_ENV=dev app sh -c "bin/console cache:warmup --no-optional-warmers && vendor/bin/phpstan analyse"
+script:
+    - .travis/test/smoke
+    - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run app vendor/bin/phpunit
+    - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run app vendor/bin/phpcs -p
+    - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run -e APP_ENV=dev app sh -c "bin/console cache:warmup --no-optional-warmers && vendor/bin/phpstan analyse"
 
 if: |
     branch = master OR \

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,10 @@ jobs:
     include:
         - stage: Test
           name: Tests
-          script:
+          install:
               - travis_retry docker-compose --file docker-compose.yaml build
               - travis_retry docker-compose --file docker-compose.yaml --file docker-compose.test.yaml build
+          script:
               - .travis/test/smoke
               - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run app vendor/bin/phpunit
               - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run app vendor/bin/phpcs -p

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ jobs:
               - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run -e APP_ENV=dev app sh -c "bin/console cache:warmup --no-optional-warmers && vendor/bin/phpstan analyse"
 
 stages:
+    - Build
     - Test
     - name: Code Quality
       if: type = pull_request

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ jobs:
           script:
               - travis_retry docker-compose --file docker-compose.yaml build
               - travis_retry docker-compose --file docker-compose.yaml --file docker-compose.test.yaml build
-              - docker-compose --file docker-compose.yaml up -d web && - docker-compose exec app bin/console --version
+              - docker-compose --file docker-compose.yaml up -d web
+              - docker-compose exec app bin/console --version
               - if [[ $(curl -sS http://localhost:8080/ping 2>&1) == "pong" ]]; then true; else false; fi
               - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run app vendor/bin/phpunit
               - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run app vendor/bin/phpcs -p

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
               - travis_retry docker-compose --file docker-compose.yaml build
               - travis_retry docker-compose --file docker-compose.yaml --file docker-compose.test.yaml build
               - docker-compose --file docker-compose.yaml up -d web
-              - docker-compose exec app bin/console --version
+              - docker-compose --file docker-compose.yaml exec app bin/console --version
               - if [[ $(curl -sS http://localhost:8080/ping 2>&1) == "pong" ]]; then true; else false; fi
               - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run app vendor/bin/phpunit
               - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run app vendor/bin/phpcs -p

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ jobs:
               - travis_retry docker-compose --file docker-compose.yaml --file docker-compose.test.yaml build
           script:
               - .travis/test/smoke
+              - echo "Failing check" && bash -c "exit 42;"
               - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run app vendor/bin/phpunit
               - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run app vendor/bin/phpcs -p
               - docker-compose --file docker-compose.yaml --file docker-compose.test.yaml run -e APP_ENV=dev app sh -c "bin/console cache:warmup --no-optional-warmers && vendor/bin/phpstan analyse"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ services: docker
 env:
     global:
         - APP_SECRET=secret
+        - IMAGE_TAG=$TRAVIS_COMMIT
 
 install:
     - travis_retry docker-compose --file docker-compose.yaml --file docker-compose.test.yaml build

--- a/.travis/test/smoke
+++ b/.travis/test/smoke
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+docker-compose --file docker-compose.yaml up -d web
+docker-compose --file docker-compose.yaml exec app bin/console --version
+ping=$(curl -sS http://localhost:8080/ping 2>&1)
+[[ "$ping" == "pong" ]]

--- a/.travis/test/smoke
+++ b/.travis/test/smoke
@@ -5,3 +5,4 @@ docker-compose --file docker-compose.yaml up -d web
 docker-compose --file docker-compose.yaml exec app bin/console --version
 ping=$(curl -sS http://localhost:8080/ping 2>&1)
 [[ "$ping" == "pong" ]]
+docker-compose --file docker-compose.yaml down

--- a/.travis/test/smoke
+++ b/.travis/test/smoke
@@ -1,8 +1,13 @@
 #!/bin/bash
 set -e
 
+function finish {
+    docker-compose --file docker-compose.yaml down --volumes
+}
+
+trap finish EXIT
+
 docker-compose --file docker-compose.yaml up -d web
 docker-compose --file docker-compose.yaml exec app bin/console --version
 ping=$(curl -sS http://localhost:8080/ping 2>&1)
 [[ "$ping" == "pong" ]]
-docker-compose --file docker-compose.yaml down

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -4,4 +4,4 @@ services:
     app:
         build:
             target: test
-        image: liberotest/dummy-api:${IMAGE_TAG:-master}
+        image: libero/dummy-api:${IMAGE_TAG:-master}-test

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -4,4 +4,4 @@ services:
     app:
         build:
             target: test
-        image: libero/dummy-api_test:${IMAGE_TAG:-master}
+        image: liberotest/dummy-api:${IMAGE_TAG:-master}

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -4,3 +4,4 @@ services:
     app:
         build:
             target: test
+        image: libero/dummy-api_test:${IMAGE_TAG:-master}


### PR DESCRIPTION
With a single stage, the build runs in 25% of the previous time; and we can then push a selected `prod` image that is exactly the one that has been tested.